### PR TITLE
fix(deps): bump @peculiar/asn1-* to 2.8.0 to avoid duplicate asn1-schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
             "version": "1.1.4",
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "2.6.0",
-                "@peculiar/asn1-x509": "2.6.1",
-                "@peculiar/asn1-x509-logotype": "2.6.1"
+                "@peculiar/asn1-schema": "2.8.0",
+                "@peculiar/asn1-x509": "2.8.0",
+                "@peculiar/asn1-x509-logotype": "2.8.0"
             },
             "devDependencies": {
                 "@eslint/eslintrc": "3.3.4",
@@ -286,37 +286,46 @@
             }
         },
         "node_modules/@peculiar/asn1-schema": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
-            "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+            "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
             "license": "MIT",
             "dependencies": {
-                "asn1js": "^3.0.6",
-                "pvtsutils": "^1.3.6",
+                "@peculiar/utils": "^2.0.2",
+                "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
             }
         },
         "node_modules/@peculiar/asn1-x509": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz",
-            "integrity": "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+            "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.6.0",
-                "asn1js": "^3.0.6",
-                "pvtsutils": "^1.3.6",
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/utils": "^2.0.2",
+                "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
             }
         },
         "node_modules/@peculiar/asn1-x509-logotype": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-logotype/-/asn1-x509-logotype-2.6.1.tgz",
-            "integrity": "sha512-VJV5Azg0M8TMAZfE5pB9eQOLXxc/9sGS08kVJhMQYv7dB2YBwiasp/GRZIuit+0t4Sr9FnoEpwwXAHXOlLdMnA==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-logotype/-/asn1-x509-logotype-2.8.0.tgz",
+            "integrity": "sha512-79px79a3YB8OnzVh+hbUlJKNaWymsf+im26AsgHnOhZ1859qVR4P0C4JBq/52dF8LXzNfvioqIOew1Xg7l2nDA==",
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.6.0",
-                "@peculiar/asn1-x509": "^2.6.1",
-                "asn1js": "^3.0.6",
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/utils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+            "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+            "license": "MIT",
+            "dependencies": {
                 "tslib": "^2.8.1"
             }
         },
@@ -358,7 +367,6 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -430,13 +438,13 @@
             "license": "Python-2.0"
         },
         "node_modules/asn1js": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
-            "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+            "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "pvtsutils": "^1.3.6",
-                "pvutils": "^1.1.3",
+                "pvutils": "^1.1.5",
                 "tslib": "^2.8.1"
             },
             "engines": {
@@ -803,7 +811,6 @@
             "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "author": "Postal Systems OU",
     "license": "MIT",
     "dependencies": {
-        "@peculiar/asn1-schema": "2.6.0",
-        "@peculiar/asn1-x509": "2.6.1",
-        "@peculiar/asn1-x509-logotype": "2.6.1"
+        "@peculiar/asn1-schema": "2.8.0",
+        "@peculiar/asn1-x509": "2.8.0",
+        "@peculiar/asn1-x509-logotype": "2.8.0"
     },
     "devDependencies": {
         "@eslint/eslintrc": "3.3.4",


### PR DESCRIPTION
## Problem

`@postalsys/vmc` pins `@peculiar/asn1-schema` to an exact `2.6.0` (and `@peculiar/asn1-x509` / `@peculiar/asn1-x509-logotype` to `2.6.1`). In any dependency tree that also installs the current `2.8.x` `@peculiar/asn1-*` family — for example `acme-client` → `@peculiar/x509@1.14.3`, whose siblings (`@peculiar/asn1-csr`, etc.) resolve `@peculiar/asn1-schema@2.8.0` — npm ends up with **two copies** of `@peculiar/asn1-schema` (an `2.6.0` hoisted to the root and `2.8.0` nested).

`@peculiar/asn1-schema`'s `AsnSchemaStorage` is module-level state. Two copies means a class registered via `@AsnType` in one copy's registry is invisible to the other. The concrete failure we hit was at CSR generation in `acme-client`:

```
Cannot get schema for 'CertificationRequestInfo' target
```

…because `@peculiar/x509` read the `2.6.0` registry while `CertificationRequestInfo` was registered into the `2.8.0` one.

## Fix

Bump the three `@peculiar/asn1-*` dependencies to `2.8.0`. Each `2.8.0` release depends on `@peculiar/asn1-schema@^2.8.0`, so the whole asn1 ecosystem dedupes to a single copy and the dual-package hazard disappears.

## Verification

- `npm test` (eslint + mocha) — **all 50 tests pass**, including the VMC parse and chain-validation suites.
- In a downstream tree alongside `acme-client`, this collapses `@peculiar/asn1-schema` to a single `2.8.0` and `acme.crypto.createCsr()` succeeds.